### PR TITLE
compatibility fixed

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -327,7 +327,7 @@ DummyBrowser.prototype = {
       browserName: browser.actAs,
       platform: platform,
       'screen-resolution': (browser['screen-resolution'] || null),
-      'browser-version': (browser.version || this.desiredCapabilities['browser-version']),
+      version: (browser.version || this.desiredCapabilities['browser-version']),
       name: driverConfig.name || this.desiredCapabilities.name
     };
 


### PR DESCRIPTION
I'm using sauce driver with dalekjs v0.0.4 found some compatibility bugs with the current sauce labs service
- change default viewport to false because it makes android and opera browsers to crash with error 10:08:26.034 WARN - Exception: Window handling not supported on Android
- update platforms to have Windows 8.1
- modify desiredCaps to use version instead and able to config screens.
- not sure why using reduce to verify available platforms but it skips the first entry.
- modify _generateLongName to  read long names from Dalekfile.json 
- I'm using browser config in Dalekfile.json  like this
  "chrome-mac": {
    "platform": "OS X 10.6",
    "screen-resolution": "1440x900",
    "browserName": "chrome",
    "actAs": "chrome",
    "longName": "Chrome OSX",
    "version": "35",
  },
