### PR TITLE
remove re-use of session [fixes Issue #7]

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,13 +219,6 @@ Sauce.prototype = {
     this.browserDefaults = this.browserData.driverDefaults;
     this.browserDefaults.status = this.browserData.getStatusDefaults(this.desiredCapabilities);
 
-    // check if a session is already active,
-    // if so, reuse that one
-    if(this.webdriverClient.hasSession()) {
-      deferred.resolve();
-      return deferred.promise;
-    }
-
     // start a browser session
     this._startBrowserSession(deferred, this.desiredCapabilities, this.browserDefaults);
 


### PR DESCRIPTION
reusing the sauce session can be considered as an antipattern, according to sauce-labs docs. this could cause scalability problems. Skip to reuse this, actually solves the problem of issue #7 
